### PR TITLE
Adjusted the Typeahead functionality

### DIFF
--- a/src/knockout-bootstrap.js
+++ b/src/knockout-bootstrap.js
@@ -22,15 +22,19 @@ function guid() {
 
 // Bind twitter typeahead
 ko.bindingHandlers.typeahead = {
-    init: function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-		var $element = $(element);
-		var typeaheadArr = ko.utils.unwrapObservable(valueAccessor());
-
-		$element.attr("autocomplete", "off")
+    init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+        var $element = $(element);
+        var allBindings = allBindingsAccessor();
+        var typeaheadArr = ko.utils.unwrapObservable(valueAccessor());
+        
+        $element.attr("autocomplete", "off")
 				.typeahead({
-					'source' : typeaheadArr
+				    'source': typeaheadArr,
+				    'minLength': allBindings.minLength,
+				    'items': allBindings.items,
+				    'updater': allBindings.updater
 				});
-	}
+    }
 };
 
 // Bind Twitter Progress


### PR DESCRIPTION
It is now possible to also give a minLength, items and update function to the typeahead data-bind

Use it in yout HTML as  <input type="text" data-bind="typeahead: repairlines(), minLength: 2, updater: updateViewAfterSelection, value: Description" />
