### PR TITLE
Simplify tooltip binding and make it update

### DIFF
--- a/src/knockout-bootstrap.js
+++ b/src/knockout-bootstrap.js
@@ -73,39 +73,17 @@ ko.bindingHandlers.alert = {
 
 // Bind Twitter Tooltip
 ko.bindingHandlers.tooltip = {
-    init: function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-    	// read tooltip options
-    	var tooltipBindingValues = ko.utils.unwrapObservable(valueAccessor());
-
-    	// set tooltip title
-    	var tooltipTitle = tooltipBindingValues.title;
-
-    	// set tooltip placement
-    	var tooltipPlacement = tooltipBindingValues.placement;
-
-    	// set tooltip trigger
-    	var tooltipTrigger = tooltipBindingValues.trigger;
-    	
-		var options = {
-			title: tooltipTitle
-		};
-
-		ko.utils.extend(options, ko.bindingHandlers.tooltip.options);
-
-		if (tooltipPlacement) {
-			options.placement = tooltipPlacement;
-		}
-
-		if (tooltipTrigger) {
-			options.trigger = tooltipTrigger;
-		}
-
-		$(element).tooltip(options);
-	},
-	options: {
-		placement: "top",
-		trigger: "hover"
-	}
+  update: function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+    var $element, options, tooltip;
+    options = ko.utils.unwrapObservable(valueAccessor());
+    $element = $(element);
+    tooltip = $element.data('tooltip');
+    if (tooltip) {
+      $.extend(tooltip.options, options);
+    } else {
+      $element.tooltip(options);
+    }
+  }
 };
 
 // Bind Twitter Popover


### PR DESCRIPTION
I redid the tooltip binding to accomplish a few things:
- Remove the hard-coded defaults so that it falls back on Bootstrap's defaults
- Allow for any valid tooltip options in the binding, rather than a select few, by just treating the valueAccessor as the `options` object.
- Move the code to `update` so that the tooltip will change when observable options change.
