### PR TITLE
Ability to optionally not control descendant bindings on popover

### DIFF
--- a/src/knockout-bootstrap.js
+++ b/src/knockout-bootstrap.js
@@ -164,6 +164,7 @@ function setupKoBootstrap(koObject, $) {
             var template = popoverBindingValues.template || false;
             var options = popoverBindingValues.options || {title: 'popover'};
             var data = popoverBindingValues.data || false;
+            var controlDecendents = popoverBindingValues.controlDecendents;
             if (template !== false) {
                 if (data) {
                     options.content = "<!-- ko template: { name: template, if: data, data: data } --><!-- /ko -->";
@@ -235,7 +236,7 @@ function setupKoBootstrap(koObject, $) {
 				$element.popover('destroy');
 			});
 
-            return { controlsDescendantBindings: true };
+            return { controlsDescendantBindings: typeof controlDecendents == 'undefined' ? true : controlDecendents };
 
         }
     };
@@ -298,7 +299,7 @@ function setupKoBootstrap(koObject, $) {
 			koObject.utils.domNodeDisposal.addDisposeCallback(element, function () {
 				$element.modal('destroy');
 			});
-			
+
             return { controlsDescendantBindings: true };
 
         }

--- a/src/knockout-bootstrap.js
+++ b/src/knockout-bootstrap.js
@@ -164,7 +164,7 @@ function setupKoBootstrap(koObject, $) {
             var template = popoverBindingValues.template || false;
             var options = popoverBindingValues.options || {title: 'popover'};
             var data = popoverBindingValues.data || false;
-            var controlDecendants = popoverBindingValues.controlDecendants;
+            var controlDescendants = popoverBindingValues.controlDescendants;
             if (template !== false) {
                 if (data) {
                     options.content = "<!-- ko template: { name: template, if: data, data: data } --><!-- /ko -->";
@@ -236,7 +236,7 @@ function setupKoBootstrap(koObject, $) {
 				$element.popover('destroy');
 			});
 
-            return { controlsDescendantBindings: typeof controlDecendants == 'undefined' ? true : controlDecendants };
+            return { controlsDescendantBindings: typeof controlDescendants == 'undefined' ? true : controlDescendants };
 
         }
     };

--- a/src/knockout-bootstrap.js
+++ b/src/knockout-bootstrap.js
@@ -164,7 +164,7 @@ function setupKoBootstrap(koObject, $) {
             var template = popoverBindingValues.template || false;
             var options = popoverBindingValues.options || {title: 'popover'};
             var data = popoverBindingValues.data || false;
-            var controlDecendents = popoverBindingValues.controlDecendents;
+            var controlDecendants = popoverBindingValues.controlDecendants;
             if (template !== false) {
                 if (data) {
                     options.content = "<!-- ko template: { name: template, if: data, data: data } --><!-- /ko -->";
@@ -236,7 +236,7 @@ function setupKoBootstrap(koObject, $) {
 				$element.popover('destroy');
 			});
 
-            return { controlsDescendantBindings: typeof controlDecendents == 'undefined' ? true : controlDecendents };
+            return { controlsDescendantBindings: typeof controlDecendants == 'undefined' ? true : controlDecendants };
 
         }
     };


### PR DESCRIPTION
If no option is passed the existing functionality of controlsDescendantBindings being true is maintained.

Adding `controlDescendants: false` as a binding parameter will use the knockout default handling of descendants.  

This allows the following

`<a data-bind="popover: {...}"><span data-bind="text: variable"></span></a>`

without the loss of the span's text binding

I intended to update the docs with this PR, but I can not resolve the repository with the website